### PR TITLE
Fixes for the Helm template syntax errors and format.

### DIFF
--- a/templates/dc-te.yaml
+++ b/templates/dc-te.yaml
@@ -13,8 +13,8 @@ spec:
     resources: {}
     rollingParams:
       intervalSeconds: 1
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: "25%"
+      maxUnavailable: "25%"
       timeoutSeconds: 600
       updatePeriodSeconds: 1
     type: Rolling
@@ -44,8 +44,7 @@ spec:
                   - {{ .Values.dbName | quote }}
               topologyKey: kubernetes.io/hostname
       containers:
-      -
-        name: te
+      - name: te
         image: {{ .Values.container }}
         imagePullPolicy: IfNotPresent
         env:

--- a/templates/po-insights.yaml
+++ b/templates/po-insights.yaml
@@ -6,14 +6,14 @@ metadata:
     app: insights
     group: nuodb
 spec:
-{{if eq .Values.storageMode "ephemeral"}}
+{{- if eq .Values.storageMode "ephemeral" }}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
             - { key: "nuodb.com/zone",      operator: Exists }
-{{end}}
+{{- end }}
   initContainers:
   - name: optin
     image: {{ .Values.container }}

--- a/templates/rc-ycsb.yaml
+++ b/templates/rc-ycsb.yaml
@@ -16,13 +16,13 @@ spec:
         database: {{ .Values.dbName }}
     spec:
       affinity:      
-{{if eq .Values.storageMode "ephemeral"}}
+{{- if eq .Values.storageMode "ephemeral" }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
                 - { key: "nuodb.com/zone",      operator: Exists }
-{{end}}
+{{- end }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50

--- a/templates/route-insights.yaml
+++ b/templates/route-insights.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     group: nuodb
 spec:
+  host: www.example.com
   to:
     kind: Service
     name: insights-server
+    weight: 100

--- a/templates/sts-admin.yaml
+++ b/templates/sts-admin.yaml
@@ -33,6 +33,15 @@ spec:
                 values: [ "admin" ]
             topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 15
+      initContainers:
+        # when disk is created and mounted only root can access.  We don't
+        # want to run container as root, so allow gid root to access.
+      - name: init-disk
+        image: busybox:1.28
+        command: ['chmod' , '770', '/var/opt/nuodb' ]
+        volumeMounts:
+        - name: raftlog
+          mountPath: /var/opt/nuodb
       containers:
       - name: admin
         image: {{ .Values.container }}
@@ -75,27 +84,25 @@ spec:
           periodSeconds: 15
           exec:
             command: [ "nuodocker", "check", "servers" ]
-{{if eq .Values.storageMode "persistent"}}
-          volumeMounts:
-          - name: raftlog
-            mountPath: /var/opt/nuodb
-          - name: log-volume
-            mountPath: /var/log/nuodb
-        volumes:
-          - name: log-volume
-            emptyDir: {}
-    volumeClaimTemplates:
-    - metadata:
-        name: raftlog
-        labels:
-          group: nuodb
-      spec:
-        labels:
-          app: nuodb
-          group: nuodb
-        accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.adminStorageClass}}
-        resources:
-          requests:
-            storage: {{ .Values.adminStorageSize }}
-{{end}}
+{{- if eq .Values.storageMode "persistent" }}
+        volumeMounts:
+        - name: raftlog
+          mountPath: /var/opt/nuodb
+        - name: log-volume
+          mountPath: /var/log/nuodb
+      volumes:
+        - name: log-volume
+          emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: raftlog
+      labels:
+        app: nuodb
+        group: nuodb
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.adminStorageClass | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.adminStorageSize | quote }}
+{{- end }}

--- a/templates/sts-sm.yaml
+++ b/templates/sts-sm.yaml
@@ -30,9 +30,18 @@ spec:
             nodeSelectorTerms:
               - matchExpressions:
                 - { key: "nuodb.com/zone",      operator: Exists }
-{{if eq .Values.storageMode "persistent"}}
+{{- if eq .Values.storageMode "persistent" }}
                 - { key: "nuodb.com/node-type", operator: Exists }
-{{end}}
+{{- end }}
+      initContainers:
+        # when disk is created and mounted only root can access.  We don't
+        # want to run container as root, so allow gid root to access.
+      - name: init-disk
+        image: busybox:1.28
+        command: ['chmod' , '770', '/var/opt/nuodb/archive' ]
+        volumeMounts:
+        - name: archive
+          mountPath: /var/opt/nuodb/archive
       containers:
       - name: sm
         image: {{ .Values.container }}
@@ -78,21 +87,20 @@ spec:
             cpu: {{ .Values.smCpu | quote }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
-{{if eq .Values.storageMode "persistent"}}
+{{- if eq .Values.storageMode "persistent" }}
         volumeMounts:
         - mountPath: /var/opt/nuodb/archive
           name: archive
   volumeClaimTemplates:
   - metadata:
       name: archive
-    spec:
       labels:
         app: nuodb
         group: nuodb
+    spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.smStorageClass }}
+      storageClassName: {{ .Values.smStorageClass | quote }}
       resources:
         requests:
-          storage: {{ .Values.smStorageSize }}
-{{end}}
-
+          storage: {{ .Values.smStorageSize | quote }}
+{{- end }}

--- a/templates/svc-domain.yaml
+++ b/templates/svc-domain.yaml
@@ -10,7 +10,7 @@ metadata:
     app: nuodb
     group: nuodb
 spec:
-  PublishNotReadyAddresses: true
+  publishNotReadyAddresses: true
   clusterIP: None
   ports:
   - { name: 8888-tcp,   port: 8888,   protocol: TCP,  targetPort: 8888  }


### PR DESCRIPTION
This has been tested against OCP/AWS 4.0.

**Testing:**

- use helm dry run to generate inlined YAML
- pipe inlined yaml through kubectl dry run to do lint check
- if successful, after any fixes, deploy to OCP and validate pv
  existance and do demo run

**Changes:**

- outdent of pvc templates
- chomp helm conditionals
- fix quoting of terms requiring that
- route needs host (note that it still needs status but we cannot
  find doc on that)

**Known Issues:**

- Route is missing status still, requires additional research by engineering
- TE deploy has additional Pod; we suspect that this is b/c of
  OpenShift proprietary DeploymentConfig; recommendation is for engineering
  to switch to Deployment.